### PR TITLE
Compatibility with later versions of Django

### DIFF
--- a/bank/forms.py
+++ b/bank/forms.py
@@ -20,6 +20,7 @@ class AccountForm(ModelForm):
 class TransferFormFrom(ModelForm):
     class Meta:
         model = Transaction
+        fields= '__all__'
         widgets = {
             'from_account': HiddenInput(),
         }
@@ -27,6 +28,7 @@ class TransferFormFrom(ModelForm):
 class TransferFormTo(ModelForm):
     class Meta:
         model = Transaction
+        fields= '__all__'
         widgets = {
             'to_account': HiddenInput(),
         }


### PR DESCRIPTION
Compatibility with later versions of Django (1.7, 1.8 ). 
Added required 'fields' on the 'class TransferFormFrom(ModelForm)' and 'class TransferFormTo(ModelForm)' .
